### PR TITLE
fix: update badge tooltip to support all requirement types

### DIFF
--- a/src/components/gamification/BadgeDisplay.tsx
+++ b/src/components/gamification/BadgeDisplay.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Badge } from "@/types";
 import {
   BADGE_TEMPLATES,
+  BadgeRequirement,
   RARITY_COLORS,
   RARITY_LABELS,
   getBadgeTemplate,
@@ -22,6 +23,27 @@ interface BadgeCardProps {
   badge: Badge;
   isEarned: boolean;
   onClick?: () => void;
+}
+
+function getBadgeRequirementDescription(requirement: BadgeRequirement): string {
+  switch (requirement.type) {
+    case "total_reduction":
+      return `Reduce your ${requirement.period} CO₂ footprint by ${requirement.threshold}%`;
+    case "streak_days":
+      return `Log activities for ${requirement.threshold} consecutive days`;
+    case "milestone":
+      return `Complete ${requirement.threshold} day${
+        requirement.threshold > 1 ? "s" : ""
+      } of tracking`;
+    case "activity_limit":
+      return `Keep ${requirement.activity} under ${requirement.threshold} ${requirement.period}`;
+    case "tips_applied":
+      return `Apply ${requirement.threshold} eco-friendly tips`;
+    case "consistency":
+      return `Maintain consistent eco-friendly activity tracking`;
+    default:
+      return "Complete the requirement to unlock this badge";
+  }
 }
 
 function BadgeCard({ badge, isEarned, onClick }: BadgeCardProps) {
@@ -56,10 +78,7 @@ function BadgeCard({ badge, isEarned, onClick }: BadgeCardProps) {
           </svg>
 
           <span className="text-white ">
-            This badge is earned by achieving a total CO₂ reduction of at least{" "}
-            {"  "}
-            {badge.requirement.threshold}% over a {badge.requirement.period}{" "}
-            period.
+            {getBadgeRequirementDescription(badge.requirement)}
           </span>
         </div>
       }


### PR DESCRIPTION
# 🌱 Carbon Footprint Tracker - Pull Request

## Description
<!-- Provide a brief description of your changes -->
#### Problem
Badge tooltips were hardcoded for `total_reduction` badges only, breaking for other requirement types.

- Added a `getBadgeRequirementDescription()` helper to dynamically generate tooltip text.
- Updated `BadgeDisplay.tsx` to use the new helper instead of static text.
- Supports all 6 requirement types (`total_reduction`, `streak_days`, `activity_limit`, `tips_applied`, `consistency`, `milestone`).

## Type of Change
<!-- Mark with an 'x' the applicable options -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #47 

## Testing
- [x] I have tested this change locally
- [ ] I have tested on mobile devices
- [ ] I have tested on different browsers
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## For Maintainers
- [ ] Code review completed
- [ ] Tests passing
- [ ] Documentation updated
- [ ] Ready to merge

---

**Thank you for contributing to making digital sustainability more accessible! 🌍**

*This repository participates in Hacktoberfest 2025! 🎃*
